### PR TITLE
Fixed pkg generation error with registrator

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,5 +9,4 @@ ITKIOWrapper_jll = "b6265aa4-802f-522b-a8eb-4519ac77ab09"
 
 [compat]
 CxxWrap = "0.16.0"
-ITKIOWrapper_jll = "1.0.0+2"
-julia = "1"
+


### PR DESCRIPTION
Further Please change the name of the package back to

ITKIOWrapper.jl 
to adhere with the module name